### PR TITLE
Globally Searched database hooked up

### DIFF
--- a/server/models/globallySearched.js
+++ b/server/models/globallySearched.js
@@ -33,7 +33,6 @@ const globallySearchedSchema = new mongoose.Schema(
     },
     preview_url: {
       type: String,
-      required: true,
     },
     external_urls: {
       spotify: {
@@ -50,7 +49,7 @@ const globallySearchedSchema = new mongoose.Schema(
 );
 
 const GloballySearched = mongoose.model(
-  "GloballySearched",
+  "globallySearchedSongs",
   globallySearchedSchema
 );
 module.exports = GloballySearched;

--- a/server/models/globallySearched.js
+++ b/server/models/globallySearched.js
@@ -1,0 +1,56 @@
+const mongoose = require("mongoose");
+const globallySearchedSchema = new mongoose.Schema(
+  {
+    albumCover: {
+      type: String,
+      required: true,
+    },
+    songName: {
+      type: String,
+      required: true,
+    },
+    artists: [
+      {
+        name: {
+          type: String,
+          required: true,
+        },
+      },
+    ],
+    album: {
+      name: {
+        type: String,
+        required: true,
+      },
+      images: [
+        {
+          url: {
+            type: String,
+            required: true,
+          },
+        },
+      ],
+    },
+    preview_url: {
+      type: String,
+      required: true,
+    },
+    external_urls: {
+      spotify: {
+        type: String,
+        required: true,
+      },
+    },
+    location: {
+      type: String,
+      required: true,
+    },
+  },
+  { timestamps: true }
+);
+
+const GloballySearched = mongoose.model(
+  "GloballySearched",
+  globallySearchedSchema
+);
+module.exports = GloballySearched;

--- a/server/routes/songs.js
+++ b/server/routes/songs.js
@@ -2,186 +2,7 @@ var express = require("express");
 var router = express.Router();
 const { search_songs, generate_recommendations } = require("../api");
 const LikedSongs = require("../models/likedSongs");
-
-// todo remove when we seed the db with the proper # of songs
-let globallySearchedSongs = [
-  {
-    "id": "11xC6P3iKYpFThT6Ce1KdG",
-    "name": "Attention",
-    "artists": [
-      {
-        "name": "Doja Cat"
-      }
-    ],
-    "album": {
-      "name": "Attention",
-      "images": [
-        {
-          "url": "https://i.scdn.co/image/ab67616d0000b27324b893fb9e7953ebc9517c6a"
-        }
-      ]
-    },
-    "preview_url": "https://p.scdn.co/mp3-preview/0bc92811cc92e03805da4a1a5e8d70a0dee73107?cid=07f17a9780d34fc5aac6cb73f0ca6ce8",
-    "external_urls": {
-      "spotify": "https://open.spotify.com/track/11xC6P3iKYpFThT6Ce1KdG"
-    },
-    "location": "Vancouver"
-  },
-  {
-    "id": "5xP9lQYA8YQmQh6BOxcAnR",
-    "name": "Popular (with Playboi Carti & Madonna) - The Idol Vol. 1 (Music from the HBO Original Series)",
-    "artists": [
-      {
-        "name": "The Weeknd"
-      }
-    ],
-    "album": {
-      "name": "Popular [The Idol Vol. 1 (Music from the HBO Original Series)]",
-      "images": [
-        {
-          "url": "https://i.scdn.co/image/ab67616d0000b273eac1ac267dc90bc625535a57"
-        }
-      ]
-    },
-    "preview_url": null,
-    "external_urls": {
-      "spotify": "https://open.spotify.com/track/5xP9lQYA8YQmQh6BOxcAnR"
-    },
-    "location": "Vancouver"
-  },
-  {
-    "id": "5rurggqwwudn9clMdcchxT",
-    "name": "Calling (Spider-Man: Across the Spider-Verse) (Metro Boomin & Swae Lee, NAV, feat. A Boogie Wit da Hoodie)",
-    "artists": [
-      {
-        "name": "Metro Boomin"
-      }
-    ],
-    "album": {
-      "name": "METRO BOOMIN PRESENTS SPIDER-MAN: ACROSS THE SPIDER-VERSE (SOUNDTRACK FROM AND INSPIRED BY THE MOTION PICTURE)",
-      "images": [
-        {
-          "url": "https://i.scdn.co/image/ab67616d0000b2736ed9aef791159496b286179f"
-        }
-      ]
-    },
-    "preview_url": null,
-    "external_urls": {
-      "spotify": "https://open.spotify.com/track/5rurggqwwudn9clMdcchxT"
-    },
-    "location": "Vancouver"
-  },
-  {
-    "id": "1vYXt7VSjH9JIM5oRRo7vA",
-    "name": "Dance The Night (From Barbie The Album)",
-    "artists": [
-      {
-        "name": "Dua Lipa"
-      }
-    ],
-    "album": {
-      "name": "Dance The Night (From Barbie The Album)",
-      "images": [
-        {
-          "url": "https://i.scdn.co/image/ab67616d0000b2737dd3ba455ee3390cb55b0192"
-        }
-      ]
-    },
-    "preview_url": "https://p.scdn.co/mp3-preview/acaea048f50a3b30ca24b348c84a6047373baabb?cid=07f17a9780d34fc5aac6cb73f0ca6ce8",
-    "external_urls": {
-      "spotify": "https://open.spotify.com/track/1vYXt7VSjH9JIM5oRRo7vA"
-    },
-    "location": "Vancouver"
-  },
-  {
-    "id": "7FbrGaHYVDmfr7KoLIZnQ7",
-    "name": "Cupid - Twin Ver.",
-    "artists": [
-      {
-        "name": "FIFTY FIFTY"
-      }
-    ],
-    "album": {
-      "name": "The Beginning: Cupid",
-      "images": [
-        {
-          "url": "https://i.scdn.co/image/ab67616d0000b27337c0b3670236c067c8e8bbcb"
-        }
-      ]
-    },
-    "preview_url": "https://p.scdn.co/mp3-preview/af5c16d4c69be9b3278e7079d5aab14aa425127b?cid=07f17a9780d34fc5aac6cb73f0ca6ce8",
-    "external_urls": {
-      "spotify": "https://open.spotify.com/track/7FbrGaHYVDmfr7KoLIZnQ7"
-    },
-    "location": "Vancouver"
-  },
-  {
-    "id": "7KokYm8cMIXCsGVmUvKtqf",
-    "name": "Karma",
-    "artists": [
-      {
-        "name": "Taylor Swift"
-      }
-    ],
-    "album": {
-      "name": "Midnights",
-      "images": [
-        {
-          "url": "https://i.scdn.co/image/ab67616d0000b273bb54dde68cd23e2a268ae0f5"
-        }
-      ]
-    },
-    "preview_url": null,
-    "external_urls": {
-      "spotify": "https://open.spotify.com/track/7KokYm8cMIXCsGVmUvKtqf"
-    },
-    "location": "Vancouver"
-  },
-  {
-    "id": "0yLdNVWF3Srea0uzk55zFn",
-    "name": "Flowers",
-    "artists": [
-      {
-        "name": "Miley Cyrus"
-      }
-    ],
-    "album": {
-      "name": "Flowers",
-      "images": [
-        {
-          "url": "https://i.scdn.co/image/ab67616d0000b273f429549123dbe8552764ba1d"
-        }
-      ]
-    },
-    "preview_url": "https://p.scdn.co/mp3-preview/9fbe346e805ed219204f53324f94557ab557b6d3?cid=07f17a9780d34fc5aac6cb73f0ca6ce8",
-    "external_urls": {
-      "spotify": "https://open.spotify.com/track/0yLdNVWF3Srea0uzk55zFn"
-    },
-    "location": "Vancouver"
-  },
-  {
-    "id": "1Qrg8KqiBpW07V7PNxwwwL",
-    "name": "Kill Bill",
-    "artists": [
-      {
-        "name": "SZA"
-      }
-    ],
-    "album": {
-      "name": "SOS",
-      "images": [
-        {
-          "url": "https://i.scdn.co/image/ab67616d0000b2730c471c36970b9406233842a5"
-        }
-      ]
-    },
-    "preview_url": "https://p.scdn.co/mp3-preview/4bd2dc84016f3743add7eea8b988407b1b900672?cid=07f17a9780d34fc5aac6cb73f0ca6ce8",
-    "external_urls": {
-      "spotify": "https://open.spotify.com/track/1Qrg8KqiBpW07V7PNxwwwL"
-    },
-    "location": "Vancouver"
-  }
-]
+const GloballySearchedSchema = require("../models/globallySearched");
 
 /* GET song search results . */
 router.get("/search/:searchString", async function (req, res, next) {
@@ -198,7 +19,7 @@ router.post("/recommendations/generate", async function (req, res, next) {
 // GET scoreboard data
 router.get("/scoreboard", async function (req, res, next) {
   const page = parseInt(req.query.page) || 1;
-  const songsPerPage = 5; 
+  const songsPerPage = 5;
 
   try {
     const totalSongs = await LikedSongs.countDocuments();
@@ -211,61 +32,46 @@ router.get("/scoreboard", async function (req, res, next) {
 
     res.json({ songs, totalPages });
   } catch (error) {
-    res.status(500).json({ message: 'Error getting liked songs' });
+    res.status(500).json({ message: "Error getting liked songs" });
   }
 });
 
 // GET globally searched songs
-router.get("/globallysearched", function (req, res, next) {
-  // call database
-  // const globallysearched = { globallysearched: "globallysearched" };
+router.get("/globallysearched", async function (req, res, next) {
+  try {
+    const globallySearchedSongs = await GloballySearchedSchema.find().sort({
+      createdAt: -1,
+    });
 
-  return res.json(globallySearchedSongs);
+    return res.json({ globallySearchedSongs });
+  } catch (error) {
+    res.status(500).json({ message: "Error getting globally searched songs" });
+  }
 });
 
 // POST new song searched (for globally searched)
-router.post("/globallysearched/add", function (req, res, next) {
+router.post("/globallysearched/add", async function (req, res, next) {
   const song = req.body.song;
   const location = req.body.location;
   const limit = 8;
 
-  // const data = {
-  //   id: song.id,
-  //   name: song.name,
-  //   artists: song.artists[0].name,
-  //   albumName: song.album.name,
-  //   albumImgSrc: song.album.images[0].url,
-  //   songPreview: song.preview_url,
-  //   externalUrl: song.external_urls.spotify,
-  //   location: location,
-  // };
-
-  const data = {
-    id: song.id,
-    name: song.name,
-    artists: [{name: song.artists[0].name}],
+  let globallySearchedSong = new GloballySearchedSchema({
+    albumCover: song.album.images[0].url,
+    songName: song.name,
+    artists: song.artists.map((artist) => ({ name: artist.name })),
     album: {
       name: song.album.name,
-      images: [{url: song.album.images[0].url}]
+      images: song.album.images.map((image) => ({ url: image.url })),
     },
     preview_url: song.preview_url,
     external_urls: {
-      spotify: song.external_urls.spotify
+      spotify: song.external_urls.spotify,
     },
-    location: location
-  };
+    location: location,
+  });
 
-  const songID = song.id;
+  const data = await globallySearchedSong.save();
 
-  if (globallySearchedSongs.filter(e => e.songID === songID).length === 0) {
-    globallySearchedSongs.push(data);
-  }
-
-  if (globallySearchedSongs.length > limit) {
-    globallySearchedSongs.shift()
-  }
-
-  // update database
   return res.status(201).json(data);
 });
 
@@ -287,11 +93,11 @@ router.put("/likes/update", async function (req, res) {
         artistName: song.artists[0].name,
         likes: 1,
         previewURL: song.preview_url,
-        spotifyId: song.id
+        spotifyId: song.id,
       });
       await likedSong.save();
     }
-    res.status(201).json({ song: likedSong, like: isLiked })
+    res.status(201).json({ song: likedSong, like: isLiked });
   } catch (error) {
     res.status(400).send();
   }

--- a/src/components/GloballySearched.js
+++ b/src/components/GloballySearched.js
@@ -2,11 +2,11 @@ import Carousel from "react-material-ui-carousel";
 import { Card, Paper, Typography, Container } from "@mui/material";
 import PlayableAlbumCover from "./PlayableAlbumCover";
 import useWindowDimensions from "../hooks/useWindowDimensions";
-import {useEffect, useRef} from "react";
+import { useEffect, useRef } from "react";
 import SongPopupView from "./SongPopupView";
 import { useState } from "react";
-import {fetchGloballySearchedSongs} from "../slices/globallySearchedSlice";
-import {useDispatch, useSelector} from "react-redux";
+import { fetchGloballySearchedSongs } from "../slices/globallySearchedSlice";
+import { useDispatch, useSelector } from "react-redux";
 
 const styles = {
   carousel: {
@@ -24,7 +24,7 @@ const styles = {
     "&:hover": { backgroundColor: "#193044" },
     wordWrap: "normal",
     width: "240px",
-    height: "300px",
+    height: "350px",
     alignItems: "left",
     padding: "0px 25px",
     margin: "0px 0px",
@@ -43,17 +43,17 @@ const styles = {
 };
 
 export default function GloballySearched() {
-  const songs = useSelector(state => state.globallySearched.globallySearched)
-  const songsStatus = useSelector(state => state.globallySearched.status)
+  const songs = useSelector((state) => state.globallySearched.globallySearched);
+  const songsStatus = useSelector((state) => state.globallySearched.status);
   const dispatch = useDispatch();
 
-  useEffect(()=> {
+  useEffect(() => {
     if (songsStatus === "idle") {
-      dispatch(fetchGloballySearchedSongs())
+      dispatch(fetchGloballySearchedSongs());
     }
-  }, [songsStatus, dispatch])
+  }, [songsStatus, dispatch]);
 
-  const {width} = useWindowDimensions();
+  const { width } = useWindowDimensions();
 
   const [selectedSong, setSelectedSong] = useState(null);
   const [displayPopup, setDisplayPopup] = useState(false);
@@ -61,13 +61,11 @@ export default function GloballySearched() {
   const carouselWidth = Math.min(1000, width * 0.8);
 
   let songWidth =
-      parseInt(styles.carouselSong.padding) * 2 +
-      parseInt(styles.carouselSong.width);
+    parseInt(styles.carouselSong.padding) * 2 +
+    parseInt(styles.carouselSong.width);
 
   const songsPerGroup = Math.floor(carouselWidth / songWidth);
-
   const nGroups = Math.floor(songs.length / 3);
-
   const songGroups = [];
 
   for (let i = 0; i < nGroups; i++) {
@@ -89,49 +87,49 @@ export default function GloballySearched() {
   };
 
   return (
-      <div>
-        <Typography
-            noWrap={true}
-            align='center'
-            variant='h5'
-            style={{margin: "25px"}}
+    <div>
+      <Typography
+        noWrap={true}
+        align="center"
+        variant="h5"
+        style={{ margin: "25px" }}
+      >
+        Songs Searched for Globally
+      </Typography>
+      <Card sx={styles.carousel} id="carousel">
+        <Carousel
+          animation="slide"
+          indicators={false}
+          duration={500}
+          autoPlay={true}
         >
-          Songs Searched for Globally
-        </Typography>
-        <Card sx={styles.carousel} id='carousel'>
-          <Carousel
-              animation='slide'
-              indicators={false}
-              duration={500}
-              autoPlay={true}
-          >
-            {songGroups.map((group, i) => {
-              return (
-                  <SongGroup
-                      key={i}
-                      songs={group}
-                      handleSelect={handleSelect}
-                      handleClose={handleClose}
-                  />
-              );
-            })}
-            {}
-          </Carousel>
-        </Card>
-        {displayPopup && selectedSong && (
-            <SongPopupView
-                song={selectedSong}
+          {songGroups.map((group, i) => {
+            return (
+              <SongGroup
+                key={i}
+                songs={group}
+                handleSelect={handleSelect}
                 handleClose={handleClose}
-                isDisplayed={displayPopup}
-            />
-        )}
-      </div>
+              />
+            );
+          })}
+          {}
+        </Carousel>
+      </Card>
+      {displayPopup && selectedSong && (
+        <SongPopupView
+          song={selectedSong}
+          handleClose={handleClose}
+          isDisplayed={displayPopup}
+        />
+      )}
+    </div>
   );
 }
 
 function SongGroup({ songs, handleSelect }) {
   return (
-    <Paper sx={styles.carouselSongGroup} className='carousel-song-group'>
+    <Paper sx={styles.carouselSongGroup} className="carousel-song-group">
       {songs.map((song, i) => {
         return <Song key={i} song={song} handleSelect={handleSelect} />;
       })}
@@ -153,13 +151,13 @@ function Song({ song, handleSelect }) {
   return (
     <Container
       sx={styles.carouselSong}
-      className='carousel-song'
+      className="carousel-song"
       onClick={songClickRedirect}
     >
-      <Typography variant='p' sx={styles.carouselSongTitle}>
-        {song.name}
+      <Typography variant="p" sx={styles.carouselSongTitle}>
+        {song.songName}
       </Typography>
-      <Typography variant='p' sx={styles.carouselSongArtist}>
+      <Typography variant="p" sx={styles.carouselSongArtist}>
         {song.artists[0].name}
       </Typography>
       <PlayableAlbumCover

--- a/src/components/GloballySearched.js
+++ b/src/components/GloballySearched.js
@@ -26,6 +26,7 @@ const styles = {
     width: "240px",
     height: "350px",
     alignItems: "left",
+    justifyContent: "center",
     padding: "0px 25px",
     margin: "0px 0px",
     display: "flex",
@@ -65,7 +66,7 @@ export default function GloballySearched() {
     parseInt(styles.carouselSong.width);
 
   const songsPerGroup = Math.floor(carouselWidth / songWidth);
-  const nGroups = Math.floor(songs.length / 3);
+  const nGroups = Math.floor(songs.length / 4);
   const songGroups = [];
 
   for (let i = 0; i < nGroups; i++) {

--- a/src/components/ScoreboardSongCard.js
+++ b/src/components/ScoreboardSongCard.js
@@ -13,7 +13,7 @@ export const ScoreboardSongCard = ({ song, ranking }) => {
         />
       </TableCell>
       <TableCell>{song.songName}</TableCell>
-      <TableCell>{song.artisName}</TableCell>
+      <TableCell>{song.artistName}</TableCell>
       <TableCell>{song.likes}</TableCell>
     </TableRow>
   );

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -71,18 +71,18 @@ function Search() {
       <ThemeProvider theme={lightTheme}>
         <Grid
           container
-          direction='row'
-          alignItems='center'
-          justifyContent='center'
+          direction="row"
+          alignItems="center"
+          justifyContent="center"
         >
           <Grid item>
             <label>Song Name:</label>
           </Grid>
           <Grid item p={3}>
             <TextField
-              id='outlined-basic'
-              variant='outlined'
-              size='small'
+              id="outlined-basic"
+              variant="outlined"
+              size="small"
               value={songSearchString}
               onChange={(e) => {
                 handleSearch(e);
@@ -91,8 +91,8 @@ function Search() {
           </Grid>
           <Grid>
             <Button
-              variant='contained'
-              color='success'
+              variant="contained"
+              color="success"
               onClick={() => {
                 handleClickSearch();
               }}

--- a/src/slices/globallySearchedSlice.js
+++ b/src/slices/globallySearchedSlice.js
@@ -1,38 +1,36 @@
-import {createAsyncThunk, createSlice} from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
 
 const initialState = {
-    globallySearched: [],
-    status: 'idle',
-    error: null
-}
+  globallySearched: [],
+  status: "idle",
+  error: null,
+};
 export const fetchGloballySearchedSongs = createAsyncThunk(
-    "songs/globallySearched",
-    async (payload, thunkAPI) => {
-        try {
-            return await axios.get(
-                'http://localhost:5001/songs/globallysearched'
-            );
-        } catch (error) {
-            console.error(error);
-
-        }
+  "songs/globallySearched",
+  async (payload, thunkAPI) => {
+    try {
+      return await axios.get("http://localhost:5001/songs/globallysearched");
+    } catch (error) {
+      console.error(error);
     }
-)
+  }
+);
 
 const globallySearchedSlice = createSlice({
-    name: "globallySearched",
-    initialState: initialState,
-    reducers: {},
-    extraReducers(builder) {
-        builder.addCase(fetchGloballySearchedSongs.fulfilled, (state, action) => {
-            state.globallySearched = action.payload.data;
-            state.status = 'succeeded'
-            // return action.payload;
-        });
-    }
-})
+  name: "globallySearched",
+  initialState: initialState,
+  reducers: {},
+  extraReducers(builder) {
+    builder.addCase(fetchGloballySearchedSongs.fulfilled, (state, action) => {
+      state.globallySearched = action.payload.data.globallySearchedSongs;
+      state.status = "succeeded";
+      return state;
+    });
+  },
+});
 
 export default globallySearchedSlice.reducer;
 
-export const getGloballySearched = state => state.globallySearched.globallySearched;
+export const getGloballySearched = (state) =>
+  state.globallySearched.globallySearched;


### PR DESCRIPTION
- working off of parm's branch
- added a new collection to the db called `GloballySearchedSongs`
- when the user clicks on a song in the search result, it automatically populates the db with the song info 
- on refresh/when another user accesses it, it'll show the newest globally searched songs
- sorted by most recent, the first set of "song groups" has the most recently searched first 
- shows a max of 12 items
- adjusted styling slightly to accommodate longer song/album names

<img width="1358" alt="Screenshot 2023-06-22 at 5 01 16 PM" src="https://github.com/KDhieb/cpsc-455-project/assets/43652006/13b19f9a-6a84-4aca-acd0-4975cdd6bbe6">

Note : 
- copied from parm's instructions : "Simply add MONGO_URL to your .env file with the following string mongodb+srv://jkrap:<password>@vibesphere.xxcrjg2.mongodb.net/?retryWrites=true&w=majority. Just replace <password> with the actual password which I'll send in the Slack channel."
