### PR TITLE
Fix Popup View Variables

### DIFF
--- a/src/components/SongPopupView.js
+++ b/src/components/SongPopupView.js
@@ -74,10 +74,10 @@ export default function SongPopupView({ isDisplayed, handleClose, song }) {
           onClose={handleClose}
         >
           <Typography sx={{ paddingBottom: "5px" }} variant='h5'>
-            {song.name}
+            {song.name ?? song.songName}
           </Typography>
           <Typography variant='p' sx={{ color: "lightgray" }}>
-            {song.album.name}
+            {song.artists[0].name}
           </Typography>
         </BootstrapDialogTitle>
 


### PR DESCRIPTION
- name was missing because of the mongoDB schema renaming the song object, made it more robust
- swapped album name for artist name