### PR TITLE
Fixed bug affecting GloballySearched likes, added Share button functionality

### DIFF
--- a/server/models/globallySearched.js
+++ b/server/models/globallySearched.js
@@ -44,6 +44,10 @@ const globallySearchedSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
+    spotifyId: {
+      type: String,
+      required: true,
+    }
   },
   { timestamps: true }
 );

--- a/server/routes/songs.js
+++ b/server/routes/songs.js
@@ -68,6 +68,7 @@ router.post("/globallysearched/add", async function (req, res, next) {
       spotify: song.external_urls.spotify,
     },
     location: location,
+    spotifyId : song.id
   });
 
   const data = await globallySearchedSong.save();

--- a/src/components/GloballySearched.js
+++ b/src/components/GloballySearched.js
@@ -7,6 +7,7 @@ import SongPopupView from "./SongPopupView";
 import { useState } from "react";
 import { fetchGloballySearchedSongs } from "../slices/globallySearchedSlice";
 import { useDispatch, useSelector } from "react-redux";
+import { createSpotifyFormattedSongObject } from "../utils/utils";
 
 const styles = {
   carousel: {
@@ -79,7 +80,8 @@ export default function GloballySearched() {
   }
 
   const handleSelect = (song) => {
-    setSelectedSong(song);
+    const songObject = createSpotifyFormattedSongObject(song.spotifyId, song.songName, song.artistName, song.albumName, song.albumCover, song.previewURL, null);
+    setSelectedSong(songObject);
     setDisplayPopup(true);
   };
 

--- a/src/components/SongPopupView.js
+++ b/src/components/SongPopupView.js
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { styled } from "@mui/material/styles";
 import Dialog from "@mui/material/Dialog";
@@ -12,6 +12,7 @@ import PlayableAlbumCover from "./PlayableAlbumCover";
 import { Share } from "@mui/icons-material";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpotify } from "@fortawesome/free-brands-svg-icons";
+import { Snackbar } from '@mui/material';
 import LikeButton from "./LikeButton";
 
 const BootstrapDialog = styled(Dialog)(({ theme }) => ({
@@ -50,13 +51,16 @@ BootstrapDialogTitle.propTypes = {
 };
 
 export default function SongPopupView({ isDisplayed, handleClose, song }) {
+  const [openShare, setOpenShare] = useState(false);
+  const url = song.external_urls.spotify ?? `https://open.spotify.com/track/${song.id}`;
+  
   const handleSpotifyClick = () => {
-    const url = song.external_urls.spotify ?? `https://open.spotify.com/track/${song.id}`;
     window.open(url, "_blank", "noreferrer");
   };
 
   const handleShare = () => {
-    // todo - add logic for share
+    setOpenShare(true)
+    navigator.clipboard.writeText(url);
   };
 
 
@@ -108,6 +112,18 @@ export default function SongPopupView({ isDisplayed, handleClose, song }) {
           <IconButton size={"large"} onClick={handleShare}>
             <Share fontSize="'large" />
           </IconButton>
+          <Snackbar
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+            open={openShare}
+            onClose={() => setOpenShare(false)}
+            autoHideDuration={1500}
+            message="Copied Spotify link!"
+            ContentProps={{
+              style: {
+                backgroundColor: 'black',
+                color: 'white',
+              }}}
+          />
         </DialogActions>
       </BootstrapDialog>
     </div>

--- a/src/components/SongResults.js
+++ b/src/components/SongResults.js
@@ -26,7 +26,6 @@ export default function SongResults({
   };
 
   const handleFavoritedCallback = () => {
-    // todo add logic for favorite
     favoritedRef.current = true;
   };
 


### PR DESCRIPTION
- added `spotifyId` to the MongoDB schema, so likes are now working through the `SongPopupView` via `GloballySearched`
- added functionality to the "Share" button (copies Spotify url directly to clipboard) + popup showing confirmation 

<img width="1440" alt="Screenshot 2023-06-25 at 9 14 42 AM" src="https://github.com/KDhieb/cpsc-455-project/assets/43652006/5901ecf6-876a-4929-b57c-fc2734027859">

