### PR TITLE
Changed the search results so the scroll doesn't appear behind the subheader

### DIFF
--- a/src/components/SongResults.js
+++ b/src/components/SongResults.js
@@ -39,30 +39,40 @@ export default function SongResults({
     }
   };
 
-  return (
+    return (
     <Box display='flex' justifyContent='center' sx={{ mb: 2 }}>
-      <Paper
-        className='results-container'
-        elevation={3}
-        sx={{ borderRadius: 2, overflow: "hidden", margin: "10px 10px" }}
-      >
-        <List
-          className='results-list'
-          sx={{
-            width: "100%",
-            maxWidth: "md",
-            bgcolor: "background.paper",
-            maxHeight: "500px",
-            overflow: "hidden",
-            overflowY: "scroll",
-          }}
+        <Paper
+            className='results-container'
+            elevation={3}
+            sx={{ borderRadius: 2, overflow: "hidden", margin: "10px 10px"}}
         >
-          <ListSubheader sx={{ marginLeft: 2 }}>
-            {isSearchResults
-              ? "Search Results"
-              : `Songs similar to: ${selectedSongFromSearch.name} by ${selectedSongFromSearch.artists[0].name}`}
-          </ListSubheader>
-
+            <ListSubheader sx={{ paddingLeft: 3 }}>
+                {isSearchResults
+                    ? "Search Results"
+                    : `Songs similar to: ${selectedSongFromSearch.name} by ${selectedSongFromSearch.artists[0].name}`}
+            </ListSubheader>
+            <List
+                className='results-list'
+                sx={{
+                    width: "100%",
+                    maxWidth: "md",
+                    bgcolor: "background.paper",
+                    maxHeight: "500px",
+                    overflow: "hidden",
+                    overflowY: "scroll",
+                    // scrollbarColor: "rgb(5, 30, 52)",
+                    "&::-webkit-scrollbar": {
+                        width: "10px"
+                    },
+                    "&::-webkit-scrollbar-track": {
+                        background: "rgb(5, 30, 52)"
+                    },
+                    "&::-webkit-scrollbar-thumb": {
+                        background: "rgb(255, 255, 255,.8)",
+                        borderRadius: "10px"
+                    }
+                }}
+            >
           {songs.map((song) => (
             <ListItemButton
               key={song.id}

--- a/src/components/SongResults.js
+++ b/src/components/SongResults.js
@@ -60,7 +60,6 @@ export default function SongResults({
                     maxHeight: "500px",
                     overflow: "hidden",
                     overflowY: "scroll",
-                    // scrollbarColor: "rgb(5, 30, 52)",
                     "&::-webkit-scrollbar": {
                         width: "10px"
                     },


### PR DESCRIPTION
- scrolling the overflow doesn't go behind the subheader "Search Results"
- also added a custom scroll bar to make it more seamless
- Before:
<img width="977" alt="image" src="https://github.com/KDhieb/cpsc-455-project/assets/75541965/65672070-85c7-4e11-8983-f7c0fb434105">

- After:
<img width="978" alt="image" src="https://github.com/KDhieb/cpsc-455-project/assets/75541965/c6a94e07-e6a4-4b94-bdff-ceed8886e89f">

