### PR TITLE
Fix likes from pop-up not working

### DIFF
--- a/src/components/GloballySearched.js
+++ b/src/components/GloballySearched.js
@@ -80,7 +80,15 @@ export default function GloballySearched() {
   }
 
   const handleSelect = (song) => {
-    const songObject = createSpotifyFormattedSongObject(song.spotifyId, song.songName, song.artistName, song.albumName, song.albumCover, song.previewURL, null);
+    const songObject = createSpotifyFormattedSongObject(
+      song.spotifyId,
+      song.songName,
+      song.artists[0].name,
+      song.albumName,
+      song.albumCover,
+      song.previewURL,
+      null
+    );
     setSelectedSong(songObject);
     setDisplayPopup(true);
   };


### PR DESCRIPTION
Fix likes not going through because improper value being passed to `createSpotifyFormattedSongObject` resulting in MongoDB rejecting a document from being created because of a missing artist name

Should be `song.artists[0].name` instead of `song.artistName`